### PR TITLE
tilt: update tiltfile to use 'add' and 'run'

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -8,10 +8,10 @@ def blorgly_backend(env):
   entrypoint = '/app/server'
   image = build_docker_image('Dockerfile.base', 'gcr.io/blorg-dev/blorgly-backend:' + env + '-' + local('whoami').rstrip('\n'), entrypoint)
   src_dir = '/go/src/github.com/windmilleng/blorgly-backend'
-  image.add_mount(src_dir, git_repo('.'))
-  image.add_cmd('cd ' + src_dir + '; go get ./...')
-  image.add_cmd('mkdir -p /app')
-  image.add_cmd('cd ' + src_dir + '; go build -o server; cp server /app/')
+  image.add(src_dir, git_repo('.'))
+  image.run('cd ' + src_dir + '; go get ./...')
+  image.run('mkdir -p /app')
+  image.run('cd ' + src_dir + '; go build -o server; cp server /app/')
   # print(image)
   yaml = local('python populate_config_template.py ' + env + ' 1>&2 && cat k8s-conf.generated.yaml')
 


### PR DESCRIPTION
Hello @dmiller, @landism,

Please review the following commits I made in branch maiamcc/tiltfile-add-run:

1912e7d722e57145ec9c3722f4509b1d7030275c (2018-08-22 16:07:58 -0400)
tilt: update tiltfile to use 'add' and 'run'

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics